### PR TITLE
Ensure the value is returned as a date

### DIFF
--- a/src/date.js
+++ b/src/date.js
@@ -14,7 +14,7 @@ module.exports = new GraphQLScalarType({
   },
   parseLiteral(ast) {
     if (ast.kind === Kind.INT) {
-      return parseInt(ast.value, 10);
+      return new Date(parseInt(ast.value, 10));
     }
     return null;
   },


### PR DESCRIPTION
When passing a literal value for a date (rather than a defined variable definition), the value is not properly transformed into a Date.

Assuming the following pseudo setup:

```graphql
scalar Date
query {
  isDate(date: Date!): String
}
```
```js
const { DateType } = require('@limit0/graphql-custom-types');
const resolvers = {
  Date: DateType,
  test: (_, { date }) => typeof date,
};
```

Currently works:
```graphql
query IsDate($date: Date!) {
  isDate(date: $date)
}
```
```js
{ date: 1664427600000 }
```

Should work but does not
```graphql
query {
  isDate(date: 1664427600000)
}
```